### PR TITLE
👷 Move image build stage to master executor

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,14 +3,18 @@
 // https://github.com/feedhenry/fh-pipeline-library
 @Library('fh-pipeline-library') _
 
+final String COMPONENT = 'memcached'
+final String VERSION = '1.4.15'
+final String DOCKER_HUB_ORG = "rhmap"
+final String DOCKER_HUB_REPO = COMPONENT
+
+String BUILD = ""
+String CHANGE_URL = ""
+
 fhBuildNode(['label': 'openshift']) {
 
-    final String COMPONENT = 'memcached'
-    final String VERSION = '1.4.15'
-    final String BUILD = env.BUILD_NUMBER
-    final String DOCKER_HUB_ORG = "rhmap"
-    final String DOCKER_HUB_REPO = COMPONENT
-    final String CHANGE_URL = env.CHANGE_URL
+    BUILD = env.BUILD_NUMBER
+    CHANGE_URL = env.CHANGE_URL
 
     stage('Platform Update') {
         final Map updateParams = [
@@ -22,15 +26,25 @@ fhBuildNode(['label': 'openshift']) {
         fhCoreOpenshiftTemplatesComponentUpdate(updateParams)
     }
 
+    stash COMPONENT
+    archiveArtifacts writeBuildInfo('memcached-container', "${VERSION}-${BUILD}")
+}
+
+node('master') {
     stage('Build Image') {
+        unstash COMPONENT
+
         final Map params = [
                 fromDir: '.',
                 buildConfigName: COMPONENT,
                 imageRepoSecret: "dockerhub",
                 outputImage: "docker.io/${DOCKER_HUB_ORG}/${DOCKER_HUB_REPO}:${VERSION}-${BUILD}"
         ]
-        buildWithDockerStrategy params
-        archiveArtifacts writeBuildInfo('memcached-container', "${VERSION}-${BUILD}")
-    }
 
+        try {
+            buildWithDockerStrategy params
+        } finally {
+            sh "rm -rf *"
+        }
+    }
 }


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/RHMAP-21735

This is to allow us to run builds in more constrained environments: we no longer need Jenkins master, and an agent pod, and a build running -- we just trigger the build from the master.